### PR TITLE
remove the dead twitter link and add the Slack channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ An embeddable private network stack for mobile, web, and devices
 <p>A <a href="https://github.com/telehash/telehash.org/tree/master/v3">version 3 of the protocol</a> is being actively stabilized with <a href="https://github.com/telehash/">multiple interoperable implementations in development</a>.  The efforts are loosely coordinated through <a href="https://github.com/telehash/telehash.org/">github</a>, anyone is welcome to contribute.
 </p>
 <p>
-Questions can be filed as issues, asked via <a href="http://twitter.com/jeremie">twitter</a>, or to <a href="xmpp:jer@jabber.org">Jeremie Miller</a> directly.
+Questions can be filed as issues, asked via the Telehash Slack channel <a href="https://telehash.slack.com">Slack</a>, or to <a href="xmpp:jer@jabber.org">Jeremie Miller</a> directly.
 </p>
 </div>
 </div>


### PR DESCRIPTION
remove the bad twitter link and add the Slack channel link